### PR TITLE
Use Responses API for screenshot renaming

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,66 +1,113 @@
-import os
 import base64
+import os
+import re
+from typing import Optional
+
 import requests
 
 ####### MODIFY THIS ########
 api_key = "YOUR_OPENAI_API_KEY"  # Replace with your actual API key
 directory = "Path_to_folder"  # Folder where the screenshots are located
 
-# Function to encode the image and convert PNG to JPEG if necessary
-def encode_image(image_path):
-  with open(image_path, "rb") as image_file:
-    return base64.b64encode(image_file.read()).decode('utf-8')
 
-# Function to get a new name from GPT-4 Vision
-def get_new_name(api_key, base64_image):
+def encode_image(image_path: str) -> str:
+  """Return a base64 encoded representation of the provided image."""
+
+  with open(image_path, "rb") as image_file:
+    return base64.b64encode(image_file.read()).decode("utf-8")
+
+
+def _limit_and_sanitize_description(text: str) -> Optional[str]:
+  """Return a filesystem-friendly, five-word-or-fewer description."""
+
+  if not text:
+    return None
+
+  words = re.findall(r"[\w'-]+", text)
+  if not words:
+    return None
+
+  limited_words = words[:5]
+  sanitized = "_".join(limited_words)
+  return sanitized.strip("._") or None
+
+
+def get_new_name(api_key: str, base64_image: str) -> Optional[str]:
   headers = {
+    "Authorization": f"Bearer {api_key}",
     "Content-Type": "application/json",
-    "Authorization": f"Bearer {api_key}"
   }
 
   payload = {
-    "model": "gpt-4-vision-preview",
-    "messages": [
+    "model": "gpt-4o-mini",
+    "input": [
       {
         "role": "user",
         "content": [
-          {"type": "text", "text": "Describe the content of this screenshot in a maximum 5 words to rename the file"},
-          {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{base64_image}", "detail": "low"}} #detail is set to low to minimize token cost
-        ]
+          {
+            "type": "input_text",
+            "text": "Describe the content of this screenshot in at most five words for a filename.",
+          },
+          {
+            "type": "input_image",
+            "image_base64": base64_image,
+          },
+        ],
       }
     ],
-    "max_tokens": 300
+    "max_output_tokens": 30,
   }
 
-  response = requests.post("https://api.openai.com/v1/chat/completions", headers=headers, json=payload)
+  response = requests.post(
+    "https://api.openai.com/v1/responses", headers=headers, json=payload, timeout=30
+  )
   print(f"Response Status Code: {response.status_code}")  # Debugging line
-  print(f"Response Content: {response.json()}")  # Debugging line
-  if response.status_code == 200:
-    result = response.json()
-    # Corrected line here
-    description = result['choices'][0]['message']['content']
-    return description.strip().replace(" ", "_") + ".png"
-  else:
+  try:
+    response_data = response.json()
+  except ValueError:
+    print(f"Non-JSON response: {response.text}")
+    return None
+
+  print(f"Response Content: {response_data}")  # Debugging line
+
+  if response.status_code != 200:
     print(f"Error processing image: {response.text}")
     return None
 
+  try:
+    description = response_data["output"][0]["content"][0]["text"]
+  except (KeyError, IndexError, TypeError) as error:
+    print(f"Unexpected response structure: {error}")
+    return None
+
+  return _limit_and_sanitize_description(description)
+
 # Function to rename screenshots in the directory
-def rename_screenshots(directory, api_key):
+def rename_screenshots(directory: str, api_key: str) -> None:
   print(f"Scanning directory: {directory}")
   files_found = os.listdir(directory)
   print(f"Files found: {files_found}")
   for filename in files_found:
-    if filename.startswith("Capture") and filename.endswith('.png'):  # Ensure this matches your files
-      print(f"Processing file: {filename}")
+    if filename.startswith("Capture"):
       file_path = os.path.join(directory, filename)
+      if not os.path.isfile(file_path):
+        continue
+
+      name_root, extension = os.path.splitext(filename)
+      if not extension:
+        print(f"Skipping '{filename}' because it has no extension")
+        continue
+
+      print(f"Processing file: {filename}")
       base64_image = encode_image(file_path)
-      new_name = get_new_name(api_key, base64_image)
-      if new_name:
-        new_file_path = os.path.join(directory, new_name)
-        print(f"Attempting to rename '{filename}' to '{new_name}'")
+      description = get_new_name(api_key, base64_image)
+      if description:
+        new_filename = f"{description}{extension}"
+        new_file_path = os.path.join(directory, new_filename)
+        print(f"Attempting to rename '{filename}' to '{new_filename}'")
         os.rename(file_path, new_file_path)
       else:
         print(f"Could not get a new name for {filename}")
 
-# Example usage
-rename_screenshots(directory, api_key)
+if __name__ == "__main__":
+  rename_screenshots(directory, api_key)


### PR DESCRIPTION
## Summary
- update the screenshot renaming helper to call the Responses API with gpt-4o-mini and an input_text/input_image pair
- parse assistant output from the Responses payload, enforce a five-word filename limit, and preserve the original extension
- harden the rename loop with filename checks, a __main__ guard, and helper sanitization utilities

## Testing
- python - <<'PY'
import base64
import os
import types
import sys
from unittest.mock import patch

class DummyResponse:
  status_code = 200
  text = ""

  def json(self):
    return {
      "output": [
        {
          "content": [
            {
              "type": "output_text",
              "text": "Purple sunset over distant mountains"
            }
          ]
        }
      ]
    }


def dummy_post(*args, **kwargs):
  return DummyResponse()

fake_requests = types.ModuleType("requests")
fake_requests.post = dummy_post
sys.modules.setdefault("requests", fake_requests)

import main

sample_dir = "./sample_screens"
os.makedirs(sample_dir, exist_ok=True)
image_path = os.path.join(sample_dir, "CaptureTest.png")
if not os.path.exists(image_path):
  pixel = base64.b64decode(
    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFgwJ/lOCS4QAAAABJRU5ErkJggg=="
  )
  with open(image_path, "wb") as handle:
    handle.write(pixel)

with patch("main.requests.post", side_effect=dummy_post):
  main.rename_screenshots(sample_dir, "fake-key")

print("Renamed files:", os.listdir(sample_dir))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e419a856a08321a898583e1f419c45