### PR TITLE
Update docs and script for Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
-
 # ScreenshotRenamer
 
 ## Description
 
-This Python script automates the renaming of screenshot files within a specified directory using the GPT-4 Vision API. By analyzing the content of each image, the script generates a concise new filename, making file management more organized and meaningful.
+This Python script automates the renaming of screenshot files within a specified directory using OpenAI's GPT-4o mini vision-capable model. The tool now calls the Responses API, which offers lower per-screenshot pricing compared to the legacy Chat Completions workflow while still producing concise, descriptive filenames for quick organization.
 
 ## Getting Started
 
 ### Prerequisites
 
 - Python 3.x installed on your system.
-- An OpenAI API key.
+- An OpenAI API key with access to GPT-4o mini or another compatible Responses API model.
 
 ### Dependencies
 
-- requests library, which can be installed via pip:
+Install the single runtime dependency with pip:
 
 ```bash
 pip install requests
@@ -22,55 +21,55 @@ pip install requests
 
 ### Setup
 
-1. **Inserting Your API Key**
+1. **Insert Your API Key**
 
-The script requires an OpenAI API key to communicate with the GPT-4 Vision API. You'll find a placeholder in the script where you can insert your key:
+   Open `main.py` and replace the placeholder with your actual API key:
 
-```python
-api_key = "YOUR_OPENAI_API_KEY"  # Replace with your actual API key
-```
+   ```python
+   API_KEY = "YOUR_OPENAI_API_KEY"
+   ```
 
-- **Where to Find Your API Key:** Log in to your OpenAI account and navigate to the API section to find your key.
-- **How to Insert Your Key:** Replace `"YOUR_OPENAI_API_KEY"` with your actual key, ensuring it's within quotes. For example:
+   - Log in to your OpenAI account, create a key from the API dashboard, and keep it secret.
+   - Consider loading the key from an environment variable when running in production scripts.
 
-```python
-api_key = "sk-youractualapikeyhere"
-```
+2. **Point to Your Screenshot Folder**
 
-2. **Specifying the Directory**
+   Update the `DIRECTORY` constant so the script scans the correct location:
 
-You need to specify the directory where your screenshots are located. There's a line in the script for this purpose:
+   ```python
+   DIRECTORY = "Path_to_folder"
+   ```
 
-```python
-directory = "Path_to_folder"  # Folder where the screenshots are located
-```
+   - Use an absolute path for clarity, such as `"C:\\Users\\YourName\\Pictures\\Screenshots"` on Windows or `"/home/yourname/Pictures/Screenshots"` on Linux/macOS.
 
-- **Finding the Path:** This is the path to the folder on your computer or server where the screenshots you want to rename are stored.
-- **How to Insert the Path:** Replace `"Path_to_folder"` with the actual path to your directory. Use an absolute path for clarity.
+3. **Choose the Model and Token Limits**
 
-For example, on a Windows system:
+   The default configuration targets the cost-efficient `gpt-4o-mini` model and keeps generations brief:
 
-```python
-directory = "C:\Users\YourName\Pictures\Screenshots"
-```
+   ```python
+   MODEL_NAME = "gpt-4o-mini"
+   MAX_OUTPUT_TOKENS = 60
+   ```
 
-Or on a Unix/Linux system:
+   - Supply another Responses API vision model if you need different capabilities.
+   - Short prompts plus a small `MAX_OUTPUT_TOKENS` value help minimize token usage and cost per rename.
+   - You can adjust `MAX_OUTPUT_TOKENS` if you need longer filenames—just remember that higher limits may increase spend.
 
-```python
-directory = "/home/yourname/Pictures/Screenshots"
-```
+4. **Run the Script**
 
-3. **Understanding and Modifying the Code**
+   From the project directory, execute:
 
-- **Encoding Images:** The encode_image function reads an image file, encodes it in base64 format, and returns the encoded string. This is required for the API request.
+   ```bash
+   python main.py
+   ```
 
-- **Renaming Logic:** The get_new_name function sends the encoded image to the GPT-4 Vision API and asks for a short description to use as a new filename. It handles the API response, extracting the description, and formats it as a valid filename.
+   Every screenshot that begins with `Capture` and ends with `.png` will be renamed with a concise description returned by GPT-4o mini. Modify the logic in `rename_screenshots` if your screenshots follow a different naming pattern.
 
-- **Renaming Files:** The rename_screenshots function looks for files in the specified directory that match a naming pattern (default is files starting with "Capture" and ending with '.png'). It then processes each file, calls get_new_name to get a new name, and renames the file.
+## How It Works
 
-4. **Customization**
+1. Each screenshot is base64-encoded.
+2. The encoded image plus a short text prompt are sent to the Responses API (`https://api.openai.com/v1/responses`).
+3. GPT-4o mini responds with a five-word (or shorter) description.
+4. The script sanitizes the text and renames the file accordingly.
 
-**File Naming Convention:** If your screenshots have a different naming convention, modify the conditions in the rename_screenshots function accordingly.
-```python
- if filename.startswith("Capture") and filename.endswith('.png'): # Ensure this matches your files
-```
+With the switch to the Responses API, you keep image processing costs low while benefiting from GPT-4o mini's fast multimodal understanding.

--- a/main.py
+++ b/main.py
@@ -1,66 +1,89 @@
 import os
 import base64
+
 import requests
 
 ####### MODIFY THIS ########
-api_key = "YOUR_OPENAI_API_KEY"  # Replace with your actual API key
-directory = "Path_to_folder"  # Folder where the screenshots are located
+API_KEY = "YOUR_OPENAI_API_KEY"  # Replace with your actual API key
+DIRECTORY = "Path_to_folder"  # Folder where the screenshots are located
+MODEL_NAME = "gpt-4o-mini"  # Vision-capable Responses API model
+MAX_OUTPUT_TOKENS = 60  # Keep responses short to minimize cost
 
-# Function to encode the image and convert PNG to JPEG if necessary
-def encode_image(image_path):
+
+def encode_image(image_path: str) -> str:
+  """Return a base64-encoded representation of an image."""
   with open(image_path, "rb") as image_file:
-    return base64.b64encode(image_file.read()).decode('utf-8')
+    return base64.b64encode(image_file.read()).decode("utf-8")
 
-# Function to get a new name from GPT-4 Vision
-def get_new_name(api_key, base64_image):
+
+def _extract_description(result: dict) -> str:
+  """Extract the first text response from a Responses API payload."""
+  text_fragments = []
+  for item in result.get("output", []):
+    for content in item.get("content", []):
+      if content.get("type") == "output_text":
+        text_fragments.append(content.get("text", ""))
+  return "".join(text_fragments).strip()
+
+
+def get_new_name(
+  api_key: str,
+  base64_image: str,
+  model_name: str = MODEL_NAME,
+  max_output_tokens: int = MAX_OUTPUT_TOKENS,
+) -> str:
+  """Call the OpenAI Responses API to generate a short description."""
   headers = {
     "Content-Type": "application/json",
-    "Authorization": f"Bearer {api_key}"
+    "Authorization": f"Bearer {api_key}",
   }
 
   payload = {
-    "model": "gpt-4-vision-preview",
-    "messages": [
+    "model": model_name,
+    "input": [
       {
         "role": "user",
         "content": [
-          {"type": "text", "text": "Describe the content of this screenshot in a maximum 5 words to rename the file"},
-          {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{base64_image}", "detail": "low"}} #detail is set to low to minimize token cost
-        ]
+          {
+            "type": "input_text",
+            "text": "Describe this screenshot in 5 words or fewer for a filename.",
+          },
+          {
+            "type": "input_image",
+            "image_url": f"data:image/png;base64,{base64_image}",
+          },
+        ],
       }
     ],
-    "max_tokens": 300
+    "max_output_tokens": max_output_tokens,
   }
 
-  response = requests.post("https://api.openai.com/v1/chat/completions", headers=headers, json=payload)
-  print(f"Response Status Code: {response.status_code}")  # Debugging line
-  print(f"Response Content: {response.json()}")  # Debugging line
-  if response.status_code == 200:
-    result = response.json()
-    # Corrected line here
-    description = result['choices'][0]['message']['content']
-    return description.strip().replace(" ", "_") + ".png"
-  else:
-    print(f"Error processing image: {response.text}")
-    return None
+  response = requests.post(
+    "https://api.openai.com/v1/responses", headers=headers, json=payload, timeout=30
+  )
+  response.raise_for_status()
+  result = response.json()
+  description = _extract_description(result)
+  if not description:
+    raise ValueError(f"No description returned for image. Full response: {result}")
+  return description.replace(" ", "_").replace("/", "-") + ".png"
 
-# Function to rename screenshots in the directory
-def rename_screenshots(directory, api_key):
-  print(f"Scanning directory: {directory}")
-  files_found = os.listdir(directory)
-  print(f"Files found: {files_found}")
-  for filename in files_found:
-    if filename.startswith("Capture") and filename.endswith('.png'):  # Ensure this matches your files
-      print(f"Processing file: {filename}")
+
+def rename_screenshots(directory: str, api_key: str) -> None:
+  """Rename screenshots in the directory based on model responses."""
+  for filename in os.listdir(directory):
+    if filename.startswith("Capture") and filename.endswith(".png"):
       file_path = os.path.join(directory, filename)
       base64_image = encode_image(file_path)
-      new_name = get_new_name(api_key, base64_image)
-      if new_name:
-        new_file_path = os.path.join(directory, new_name)
-        print(f"Attempting to rename '{filename}' to '{new_name}'")
-        os.rename(file_path, new_file_path)
-      else:
-        print(f"Could not get a new name for {filename}")
+      try:
+        new_name = get_new_name(api_key, base64_image)
+      except Exception as exc:  # pylint: disable=broad-except
+        print(f"Could not get a new name for {filename}: {exc}")
+        continue
+      new_file_path = os.path.join(directory, new_name)
+      os.rename(file_path, new_file_path)
+      print(f"Renamed '{filename}' to '{new_name}'")
 
-# Example usage
-rename_screenshots(directory, api_key)
+
+if __name__ == "__main__":
+  rename_screenshots(DIRECTORY, API_KEY)


### PR DESCRIPTION
## Summary
- document the switch to the GPT-4o mini Responses API workflow and lower-cost pricing context
- clarify configuration for API key, directory, model choice, and output token limits in README with aligned example snippet
- update main.py to call the Responses API with configurable model and token ceiling while sanitizing filenames

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e419aec5048321891c342012564462